### PR TITLE
Add formatListFields and parseListFields methods

### DIFF
--- a/lib/salesforceiq.js
+++ b/lib/salesforceiq.js
@@ -447,8 +447,7 @@ var SalesforceIQ = (function() {
   };
 
   /**
-   * Format fields for list item to match SalesforceIQ API specs,
-   * using ids pulled from the associated list
+   * Format fields for list item to match SalesforceIQ API specs, using ids pulled from the associated list
    * (c.f. https://api.salesforceiq.com/#/curl#documentation_lists_list-items_list-item-object)
    *
    * @param {string}                  listId  Reference id for the list containing these fields
@@ -605,23 +604,6 @@ var SalesforceIQ = (function() {
       } else {
         return cb(null, data);
       }
-    });
-  };
-
-  /**
-   * Update fieldValues for SalesforceIQ list item from key/value store
-   *
-   * @param {string}                   listId       Reference id for the list containing these fields
-   * @param {Object}                   fieldValues  Field data in format returned by SalesforceIQ
-   * @param {Object.<string, string>}  newData      Simple key/value store of data to update
-   * @param {Function}                 cb           Callback returning error info and parsed fields
-   */
-  SalesforceIQ.prototype.updateListFields = function(listId, fieldValues, newData, cb) {
-    this.getList(listId, function(err, list) {
-      if (err) {
-        return cb(err);
-      }
-      // @TODO: implement functionality
     });
   };
 

--- a/lib/salesforceiq.js
+++ b/lib/salesforceiq.js
@@ -344,7 +344,6 @@ var SalesforceIQ = (function() {
     }, cb);
   };
 
-
   /**
    * Get all lists from SalesforceIQ
    * @param  {Function} cb Callback
@@ -385,7 +384,7 @@ var SalesforceIQ = (function() {
   /**
    * Get list items from SalesforceIQ for a contact
    * @param  {string}   listId     The SalesforceIQ ID of the list to query
-   * @param  {Array}   contactIds An array of SalesforceIQ IDs for the contacts querying for
+   * @param  {Array}    contactIds An array of SalesforceIQ IDs for the contacts querying for
    * @param  {Function} cb         Callback
    */
   SalesforceIQ.prototype.getListItemsByContactId = function(listId, contactIds, cb) {
@@ -445,6 +444,185 @@ var SalesforceIQ = (function() {
       method: 'DELETE'
     };
     makeRequest('lists/' + listId, req, cb);
+  };
+
+  /**
+   * Format fields for list item to match SalesforceIQ API specs,
+   * using ids pulled from the associated list
+   * (c.f. https://api.salesforceiq.com/#/curl#documentation_lists_list-items_list-item-object)
+   *
+   * @param {string}                  listId  Reference id for the list containing these fields
+   * @param {Object.<string, string>} data    Simple key/value store of field data
+   * @param {Function}                cb      Callback returning error info and formatted fields
+   */
+  SalesforceIQ.prototype.formatListFields = function(listId, data, cb) {
+    this.getList(listId, function(err, list) {
+      if (err) {
+        return cb(err);
+      }
+
+      var fields = list.fields;
+      var fieldNameIds = {};
+      var fieldOptionIds = {};
+
+      _.forEach(fields, function(field) {
+        fieldNameIds[field.name] = field.id;
+
+        var optionIds = {};
+        _.forEach(field.listOptions, function(option) {
+          optionIds[option.display] = option.id;
+        });
+
+        if (optionIds) {
+          fieldOptionIds[field.name] = optionIds;
+        }
+      });
+
+      var fieldValues = {};
+
+      var invalidFieldNames = [];
+      var invalidFieldOptions = {};
+
+      _.forEach(data, function(value, name) {
+        var nameId = fieldNameIds[name];
+        if (nameId) {
+          var pickList = fieldOptionIds[name];
+          if (!_.isEmpty(pickList)) {
+            var valueId = pickList[value];
+            if (valueId) {
+              value = valueId;
+            } else {
+              var options = invalidFieldOptions[name];
+              if (options) {
+                options.push(value);
+              } else {
+                options = [value];
+              }
+              invalidFieldOptions[name] = options;
+              return;
+            }
+          }
+          fieldValues[nameId] = [{raw: value}];
+        } else {
+          invalidFieldNames.push(name);
+        }
+      });
+
+      var err = {};
+      var returnError = false;
+      if (invalidFieldNames.length > 0) {
+        err.invalidFieldNames = invalidFieldNames;
+        returnError = true;
+      }
+      if (Object.keys(invalidFieldOptions).length > 0) {
+        err.invalidFieldOptions = invalidFieldOptions;
+        returnError = true;
+      }
+
+      if (returnError) {
+        return cb(err, fieldValues);
+      } else {
+        return cb(null, fieldValues);
+      }
+    });
+  };
+
+  /**
+   * Parse fieldValues for SalesforceIQ list item as a simple key/value store
+   *
+   * @param {string}    listId       Reference id for the list containing these fields
+   * @param {Object}    fieldValues  Field data in format returned by SalesforceIQ
+   * @param {Function}  cb           Callback returning error info and parsed fields
+   */
+  SalesforceIQ.prototype.parseListFields = function(listId, fieldValues, cb) {
+    this.getList(listId, function(err, list) {
+      if (err) {
+        return cb(err);
+      }
+
+      var idToFieldName = {};
+      var idToFieldOption = {};
+
+      _.forEach(list.fields, function(field) {
+        idToFieldName[field.id] = field.name;
+
+        var optionNames = {};
+        _.forEach(field.listOptions, function(option) {
+          optionNames[option.id] = option.display;
+        });
+
+        if (optionNames) {
+          idToFieldOption[field.id] = optionNames;
+        }
+      });
+
+      var data = {};
+
+      // (unlikely to catch errors here)
+      var invalidFieldNameIds = [];
+      var invalidFieldOptionIds = {};
+
+      _.forEach(fieldValues, function(fieldData, id) {
+        var name = idToFieldName[id];
+        var valueOrValueId = fieldData[0].raw;
+
+        if (name) {
+          var pickList = idToFieldOption[id];
+          if (valueOrValueId && !_.isEmpty(pickList)) {
+            var value = pickList[valueOrValueId];
+            if (value) {
+              valueOrValueId=value;
+            } else {
+              var options = invalidFieldOptionIds[name];
+              if (options) {
+                options.push(valueOrValueId);
+              } else {
+                options = [valueOrValueId];
+              }
+              invalidFieldOptionIds[name] = options;
+              return;
+            }
+          }
+          data[name] = valueOrValueId;
+        } else {
+          invalidFieldNameIds.push(id);
+        }
+      });
+
+      var err = {};
+      var returnError = false;
+      if (invalidFieldNameIds.length > 0) {
+        err.invalidFieldNameIds = invalidFieldNameIds;
+        returnError = true;
+      }
+      if (Object.keys(invalidFieldOptionIds).length > 0) {
+        err.invalidFieldOptionIds = invalidFieldOptionIds;
+        returnError = true;
+      }
+
+      if (returnError) {
+        return cb(err, data);
+      } else {
+        return cb(null, data);
+      }
+    });
+  };
+
+  /**
+   * Update fieldValues for SalesforceIQ list item from key/value store
+   *
+   * @param {string}                   listId       Reference id for the list containing these fields
+   * @param {Object}                   fieldValues  Field data in format returned by SalesforceIQ
+   * @param {Object.<string, string>}  newData      Simple key/value store of data to update
+   * @param {Function}                 cb           Callback returning error info and parsed fields
+   */
+  SalesforceIQ.prototype.updateListFields = function(listId, fieldValues, newData, cb) {
+    this.getList(listId, function(err, list) {
+      if (err) {
+        return cb(err);
+      }
+      // @TODO: implement functionality
+    });
   };
 
   // Events

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforceiq",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SalesforceIQ API wrapper for NodeJS",
   "main": "index.js",
   "directories": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Illumineto/node-salesforceiq.git"
+    "url": "https://github.com/TechChange/node-salesforceiq.git"
   },
   "keywords": [
     "salesforce",
@@ -19,6 +19,10 @@
     "relateiq"
   ],
   "author": "Nick Caruso",
+  "contributors" : [{
+    "name": "Elana Bell Bogdan",
+    "email": "ellie@techchange.org"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Illumineto/node-salesforceiq/issues"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TechChange/node-salesforceiq.git"
+    "url": "git+https://github.com/Illumineto/node-salesforceiq.git"
   },
   "keywords": [
     "salesforce",

--- a/test/list-ops.js
+++ b/test/list-ops.js
@@ -64,7 +64,7 @@ describe('SalesforceIQ List Operations', function() {
   });
 
   it('can get filtered items from a list', function(done) {
-    salesforceIQ.getListItems(listId, 'start=0&_limit=1', function(err, res) {
+    salesforceIQ.getListItems(listId, '_start=0&_limit=1', function(err, res) {
       assert.ifError(err);
       assert.equal(res.length > 0, true);
       done();


### PR DESCRIPTION
formatListFields takes list fields and their values and formats the values into a valid object as specified by the [SalesforceIQ documentation](https://api.salesforceiq.com/#/curl#documentation_lists_list-items_list-item-object).

parseListFields turns the list items into a simple key-value store for easier manipulation of list fields.